### PR TITLE
Update cmdinfo.py

### DIFF
--- a/userge/plugins/tools/cmdinfo.py
+++ b/userge/plugins/tools/cmdinfo.py
@@ -66,7 +66,7 @@ async def see_info(message: Message):
         plugin_link = f"{extra_plugins}/{plugin_name}.py"
     elif plugin_loc == "/custom":
         custom_plugins = (
-            os.environ.get("CUSTOM_PLUGINS_REPO") or "" + "/blob/main/plugins/"
+            os.environ.get("CUSTOM_PLUGINS_REPO") or "" + "/blob/main/plugins"
         )
         plugin_link = f"{custom_plugins}/{plugin_name}.py"
     elif plugin_loc == "/temp":


### PR DESCRIPTION
removed one "/" because there were two, causing the link to show 404...
and some users like me might have just cloned unofficial plugins repo and used it as custom_plugins_repo(branch "master"), so the branch doesnt match when clicked on cmdinfo link of plugin, a suggestion